### PR TITLE
 投稿されなくてハマることがあったので、`draft`をデフォルトfalseに

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,6 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
-draft: true
+draft: false
 ---
 


### PR DESCRIPTION
- `draft=true`となっていると記事が生成されない
- 特にメッセージもないのでなんで生成されないのかなれなくてハマる
- 書き途中の記事をしたためるようなことはしなそうなのでデフォルトfalseにしてしまう

@dream-yt さんには変更を口頭で確認済み